### PR TITLE
第十五章「テスト任せとコンパイラ任せ」の実装

### DIFF
--- a/src/money.ts
+++ b/src/money.ts
@@ -1,5 +1,6 @@
 namespace Money {
-  interface Expression {
+  export interface Expression {
+    plus(addend: Expression): Expression;
     reduce(bank: Bank, to: string): Money;
   }
 
@@ -28,16 +29,22 @@ namespace Money {
   }
 
   export class Sum implements Expression {
-    public augend: Money;
-    public addend: Money;
+    public augend: Expression;
+    public addend: Expression;
 
-    constructor(augend: Money, addend: Money) {
+    constructor(augend: Expression, addend: Expression) {
       this.augend = augend;
       this.addend = addend;
     }
 
-    public reduce(bank: Bank, to: string) {
-      const amount = this.augend.getAmount() + this.addend.getAmount();
+    public plus(addend: Expression): Expression {
+      // TODO: Fake It.
+      return new Money(0, "");
+    }
+
+    public reduce(bank: Bank, to: string): Money {
+      const amount = this.augend.reduce(bank, to).getAmount()
+                   + this.addend.reduce(bank, to).getAmount();
       return new Money(amount, to);
     }
   }
@@ -51,15 +58,15 @@ namespace Money {
       this.cur = currency;
     }
 
-    public times(multiplier: number): Money {
+    public times(multiplier: number): Expression {
       return new Money(this.amount * multiplier, this.cur);
     }
 
-    public plus(addend: Money): Expression {
+    public plus(addend: Expression): Expression {
       return new Sum(this, addend);
     }
 
-    public reduce(bank: Bank, to: string) {
+    public reduce(bank: Bank, to: string): Money {
       const rate = bank.rate(this.cur, to);
       return new Money(this.amount / rate, to);
     }
@@ -79,7 +86,7 @@ namespace Money {
       return this.amount + " " + this.cur;
     }
 
-    public getAmount() {
+    public getAmount(): number {
       return this.amount;
     }
 

--- a/test/money.test.ts
+++ b/test/money.test.ts
@@ -4,8 +4,8 @@ import Money from "../src/money";
 describe("Money module", () => {
   it("Multiplication Test", () => {
     const five = Money.Money.dollar(5);
-    assert(five.times(2).equals(Money.Money.dollar(10)));
-    assert(five.times(3).equals(Money.Money.dollar(15)));
+    assert(Money.Money.dollar(10).equals(five.times(2)));
+    assert(Money.Money.dollar(15).equals(five.times(3)));
   });
 
   it("Equality Test", () => {
@@ -57,5 +57,14 @@ describe("Money module", () => {
 
   it("identity Rate Test", () => {
     assert(1 === new Money.Bank().rate("USD", "USD"));
+  });
+
+  it("Mixed Addition Test", () => {
+    const fiveBucks: Money.Money = Money.Money.dollar(5);
+    const tenFrancs: Money.Expression = Money.Money.franc(10);
+    const bank = new Money.Bank();
+    bank.addRate("CHF", "USD", 2);
+    const result = bank.reduce(fiveBucks.plus(tenFrancs), "USD");
+    assert(Money.Money.dollar(10).equals(result));
   });
 });


### PR DESCRIPTION
合わせて、一つ目のテストの assert の順序が逆になっていたため、順序を入れ替えて equals() が Money クラスのみに存在してOKな状態とした。（元の順序だと Expression インタフェースにも必要になってしまい、さらに Sum にも実装しないとだめな状態となっていた。）