### PR TITLE
第十八章「xUnitへ向かう小さな一歩」の実装

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ node_js:
   - "8"
 script:
   - npm test
+  - npm run build && npm run task:xunit
+after_success:
+  - npm run clean

--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
   },
   "scripts": {
     "lint": "tslint 'src/**/*.ts' 'test/**/*.ts'",
+    "build": "tsc --lib es2015 --outDir dist",
     "test:mocha": "mocha --require espower-typescript/guess test/**/*.ts",
     "test:watch": "mocha --watch-extensions ts -w --require espower-typescript/guess test/**/*.ts",
-    "test": "npm run lint && npm run test:mocha"
+    "test": "npm run lint && npm run test:mocha",
+    "task:xunit": "node dist/src/xunit.js",
+    "clean": "rm -fr dist && mkdir dist"
   },
   "repository": {
     "type": "git",

--- a/src/xunit.ts
+++ b/src/xunit.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+
+class TestCase {
+  protected name: string = '';
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  public run(): void {
+    const method = 'this.' + this.name + '()';
+    eval(method);
+  }
+}
+
+class WasRun extends TestCase {
+  public wasRun: boolean = false;
+
+  constructor(name: string) {
+    super(name);
+  }
+
+  public testMethod(): void {
+    this.wasRun = true;
+  }
+}
+
+class TestCaseTest extends TestCase {
+  public testRunning() {
+    const test = new WasRun('testMethod');
+    assert.ok(! test.wasRun);
+    test.run();
+    assert.ok(test.wasRun);
+  }
+}
+
+new TestCaseTest("testRunning").run();


### PR DESCRIPTION
テストフレームワークを作る実装で mocha を使えないため、 合わせて package.json に build と task、clean のスクリプトを定義して実行を簡略化することにした。