### PR TITLE
第十九章「前準備」の実装

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ node_js:
   - "8"
 script:
   - npm test
-  - npm run build && npm run task:xunit
 after_success:
   - npm run clean

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "build": "tsc --lib es2015 --outDir dist",
     "test:mocha": "mocha --require espower-typescript/guess test/**/*.ts",
     "test:watch": "mocha --watch-extensions ts -w --require espower-typescript/guess test/**/*.ts",
-    "test": "npm run lint && npm run test:mocha",
-    "task:xunit": "node dist/src/xunit.js",
+    "test:xunit": "npm run build && node dist/src/xunit.js",
+    "test": "npm run lint && npm run test:mocha && npm run test:xunit",
     "clean": "rm -fr dist && mkdir dist"
   },
   "repository": {

--- a/src/xunit.ts
+++ b/src/xunit.ts
@@ -7,7 +7,11 @@ class TestCase {
     this.name = name;
   }
 
+  public setUp(): void {
+  }
+
   public run(): void {
+    this.setUp();
     const method = 'this.' + this.name + '()';
     eval(method);
   }
@@ -15,6 +19,7 @@ class TestCase {
 
 class WasRun extends TestCase {
   public wasRun: boolean = false;
+  public wasSetUp: boolean = false;
 
   constructor(name: string) {
     super(name);
@@ -23,15 +28,29 @@ class WasRun extends TestCase {
   public testMethod(): void {
     this.wasRun = true;
   }
-}
 
-class TestCaseTest extends TestCase {
-  public testRunning() {
-    const test = new WasRun('testMethod');
-    assert.ok(! test.wasRun);
-    test.run();
-    assert.ok(test.wasRun);
+  public setUp(): void {
+    this.wasSetUp = true;
   }
 }
 
-new TestCaseTest("testRunning").run();
+class TestCaseTest extends TestCase {
+   public test: any = null;
+
+  public setUp() {
+    this.test = new WasRun('testMethod');
+  }
+
+  public testRunning() {
+    this.test.run();
+    assert.ok(this.test.wasRun);
+  }
+
+  public testSetUp() {
+    this.test.run();
+    assert.ok(this.test.wasSetUp);
+  }
+}
+
+new TestCaseTest('testRunning').run();
+new TestCaseTest('testSetUp').run();


### PR DESCRIPTION
npm の script 構成を少し見直し、`npm run test:xunit` で第二部のテストが実行される様にした。

合わせて TravisCI のテスト実行の方法も `npm run test` だけで終わる様に見直した。