### PR TITLE
第二十三章「スイートにまとめる」までで残っていた xUnit 実装の宿題の実装

### DIFF
--- a/src/xunit.ts
+++ b/src/xunit.ts
@@ -20,9 +20,9 @@ class TestCase {
     this.name = name;
   }
 
-  public setUp() { }
+  public setUp() {}
 
-  public tearDown() { }
+  public tearDown() {}
 
   public run(result: TestResult) {
     result.testStarted();
@@ -61,8 +61,10 @@ class TestResult {
 class TestSuite {
   private tests: TestCase[] = [];
 
-  public add(test: TestCase) {
-    this.tests.push(test);
+  public build(...tests: TestCase[]) {
+    tests.forEach(v => {
+      this.tests.push(v);
+    });
   }
 
   public run(result: TestResult) {
@@ -138,8 +140,7 @@ class TestCaseTest extends TestCase {
 
   public testSuite() {
     const suite = new TestSuite();
-    suite.add(new WasRun("testMethod"));
-    suite.add(new WasRun("testBrokenMethod"));
+    suite.build(new WasRun("testMethod"), new WasRun("testBrokenMethod"));
     suite.run(this.result);
     assert("2 run, 1 failed." === this.result.summary());
   }
@@ -153,12 +154,14 @@ class TestCaseTest extends TestCase {
 }
 
 const suite = new TestSuite();
-suite.add(new TestCaseTest("testTemplateMethod"));
-suite.add(new TestCaseTest("testResult"));
-suite.add(new TestCaseTest("testFailedResult"));
-suite.add(new TestCaseTest("testFailedResultFormatting"));
-suite.add(new TestCaseTest("testSuite"));
-suite.add(new TestCaseTest("testFailedSetUp"));
+suite.build(
+  new TestCaseTest("testTemplateMethod"),
+  new TestCaseTest("testResult"),
+  new TestCaseTest("testFailedResult"),
+  new TestCaseTest("testFailedResultFormatting"),
+  new TestCaseTest("testSuite"),
+  new TestCaseTest("testFailedSetUp")
+);
 const result = new TestResult();
 suite.run(result);
 console.log(result.summary());

--- a/src/xunit.ts
+++ b/src/xunit.ts
@@ -20,14 +20,14 @@ class TestCase {
     this.name = name;
   }
 
-  public setUp(): void {}
+  public setUp() { }
 
-  public tearDown(): void {}
+  public tearDown() { }
 
-  public run(result: TestResult): void {
+  public run(result: TestResult) {
     result.testStarted();
-    this.setUp();
     try {
+      this.setUp();
       const method = "this." + this.name + "()";
       eval(method);
     } catch (e) {
@@ -45,11 +45,11 @@ class TestResult {
   private runCount: number = 0;
   private errorCount: number = 0;
 
-  public testStarted(): void {
+  public testStarted() {
     this.runCount = this.runCount + 1;
   }
 
-  public testFailed(): void {
+  public testFailed() {
     this.errorCount = this.errorCount + 1;
   }
 
@@ -61,12 +61,12 @@ class TestResult {
 class TestSuite {
   private tests: TestCase[] = [];
 
-  public add(test: TestCase): void {
+  public add(test: TestCase) {
     this.tests.push(test);
   }
 
-  public run(result: TestResult): void {
-    this.tests.forEach( v => {
+  public run(result: TestResult) {
+    this.tests.forEach(v => {
       v.run(result);
     });
   }
@@ -74,24 +74,32 @@ class TestSuite {
 
 class WasRun extends TestCase {
   public log: string = "";
+  private on_error_setup: boolean = false;
 
   constructor(name: string) {
     super(name);
+  }
+
+  public setOnErrorSetUp(on_error: boolean) {
+    this.on_error_setup = on_error;
   }
 
   public testMethod(): void {
     this.log = this.log + "testMethod ";
   }
 
-  public testBrokenMethod(): void {
+  public testBrokenMethod() {
     throw new TestFailedError("testBrokenMethod() error.");
   }
 
-  public setUp(): void {
+  public setUp() {
     this.log = "setUp ";
+    if (this.on_error_setup) {
+      throw new TestFailedError("setUp() error.");
+    }
   }
 
-  public tearDown(): void {
+  public tearDown() {
     this.log = this.log + "tearDown";
   }
 }
@@ -103,36 +111,44 @@ class TestCaseTest extends TestCase {
     this.result = new TestResult();
   }
 
-  public testTemplateMethod(): void {
+  public testTemplateMethod() {
     const test = new WasRun("testMethod");
     test.run(this.result);
     assert.ok("setUp testMethod tearDown" === test.log);
   }
 
-  public testResult(): void {
+  public testResult() {
     const test = new WasRun("testMethod");
     test.run(this.result);
     assert.ok("1 run, 0 failed." === this.result.summary());
   }
 
-  public testFailedResult(): void {
+  public testFailedResult() {
     const test = new WasRun("testBrokenMethod");
     test.run(this.result);
     assert.ok("1 run, 1 failed." === this.result.summary());
+    assert.ok("setUp tearDown" === test.log);
   }
 
-  public testFailedResultFormatting(): void {
+  public testFailedResultFormatting() {
     this.result.testStarted();
     this.result.testFailed();
     assert.ok("1 run, 1 failed." === this.result.summary());
   }
 
-  public testSuite(): void {
+  public testSuite() {
     const suite = new TestSuite();
     suite.add(new WasRun("testMethod"));
     suite.add(new WasRun("testBrokenMethod"));
     suite.run(this.result);
     assert("2 run, 1 failed." === this.result.summary());
+  }
+
+  public testFailedSetUp() {
+    const test = new WasRun("testMethod");
+    test.setOnErrorSetUp(true);
+    test.run(this.result);
+    assert.ok("1 run, 1 failed." === this.result.summary());
   }
 }
 
@@ -142,6 +158,7 @@ suite.add(new TestCaseTest("testResult"));
 suite.add(new TestCaseTest("testFailedResult"));
 suite.add(new TestCaseTest("testFailedResultFormatting"));
 suite.add(new TestCaseTest("testSuite"));
+suite.add(new TestCaseTest("testFailedSetUp"));
 const result = new TestResult();
 suite.run(result);
 console.log(result.summary());


### PR DESCRIPTION
以下の三点の宿題を実装してみた。

* テストメソッドが失敗したとしても tearDown を呼び出す
  これは既に実装がそうなっていたので省略。

* setUp のエラーをキャッチして出力する
  try catch の中に setUp() の実行を含めて対応。
  WasRun クラスの setUp() で指定したフラグ on_error_setup の指定がある場合に TestFailedError 例外を発生させる処理を実装することでテストコードを実装した。

* TestCase クラスから TestSuite を作る
  TestSuite クラス内に build() を実装して、可変長の TestCase 引数を受け取る様にした。
  ここでやりたいことはなんとなく違っている気がするが、とりあえず置く。